### PR TITLE
Meson builsystem

### DIFF
--- a/aes/meson.build
+++ b/aes/meson.build
@@ -1,0 +1,4 @@
+drbg_sources += files([
+    'aes_glue.c',
+    'aes.c',
+])

--- a/drbg_common.h
+++ b/drbg_common.h
@@ -11,7 +11,7 @@
 #ifndef __DRBG_COMMON_H__
 #define __DRBG_COMMON_H__
 
-#include "utils.h"
+#include "libhash/utils.h"
 #include "helpers.h"
 
 /*** Sanity check ***/
@@ -53,7 +53,7 @@ typedef enum {
 /*********************************************/
 /********** Hash-DRBG specific data ***********/
 /*********************************************/
-#include "hash.h"
+#include "libhash/hash.h"
 /* Hash-DRBG errors */
 #define HASH_DRBG_OK		DRBG_OK
 #define HASH_DRBG_NON_INIT	DRBG_NON_INIT
@@ -105,7 +105,7 @@ typedef struct {
 /*********************************************/
 /********** HMAC-DRBG specific data ***********/
 /*********************************************/
-#include "hmac.h"
+#include "libhash/hmac.h"
 /* HMAC-DRBG errors */
 #define HMAC_DRBG_OK		DRBG_OK
 #define HMAC_DRBG_NON_INIT	DRBG_NON_INIT
@@ -150,9 +150,9 @@ typedef struct {
 /********** CTR-DRBG specific data ***********/
 /*********************************************/
 /* TDEA algorithm */
-#include "tdes.h"
+#include "libhash/tdes.h"
 /* AES algorithm */
-#include "aes.h"
+#include "aes/aes.h"
 
 /* CTR-DRBG errors */
 #define CTR_DRBG_OK		DRBG_OK

--- a/libhash/meson.build
+++ b/libhash/meson.build
@@ -1,0 +1,47 @@
+
+hash_sources = files([
+    'bash.c',
+    'bash224.c',
+    'bash256.c',
+    'bash384.c',
+    'bash512.c',
+    'belt-hash.c',
+    'gostr34_11_94.c',
+    'hash.c',
+    'hmac.c',
+    'md2.c',
+    'md4.c',
+    'md5.c',
+    'mdc2.c',
+    'ripemd160.c',
+    'sha0.c',
+    'sha1.c',
+    'sha3-224.c',
+    'sha3-256.c',
+    'sha3-384.c',
+    'sha3-512.c',
+    'sha3.c',
+    'sha224.c',
+    'sha256.c',
+    'sha384.c',
+    'sha512_core.c',
+    'sha512-224.c',
+    'sha512-256.c',
+    'sha512.c',
+    'shake.c',
+    'shake256.c',
+    'sm3.c',
+    'streebog.c',
+    'tdes.c',
+])
+
+hash_lib = static_library(
+    'hash',
+    sources: hash_sources,
+    c_args: hash_build_opts,
+)
+
+hash_dep = declare_dependency(
+    link_with: hash_lib,
+    compile_args: hash_build_opts,
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,136 @@
+project(
+    'drbg', 'c',
+    meson_version: '>=1.1.0',
+    version: run_command('dunamai', 'from', 'git', '--style', 'semver', '--dirty', check: true)
+             .stdout().strip(),
+    license: 'BSD-3-Clause OR GPL-2.0-or-later',
+    license_files: [ 'LICENSE' ],
+    default_options: ['c_std=gnu99', 'warning_level=3', 'optimization=3' ],
+)
+
+drbg_build_opts = []
+hash_build_opts = []
+
+# parse options old style (i.e. w/ define on cmdline)
+libdrgb_with_hash = get_option('with-hash-drbg')
+if libdrgb_with_hash
+    drbg_build_opts += [ '-DWITH_HASH_DRBG' ]
+endif
+summary('HASH DRBG', libdrgb_with_hash, section: 'libdrgb')
+
+libdrgb_with_hmac = get_option('with-hmac-drbg')
+if libdrgb_with_hmac
+    drbg_build_opts += [ '-DWITH_HMAC_DRBG' ]
+endif
+summary('HMAC DRBG', libdrgb_with_hmac, section: 'libdrgb')
+
+libdrgb_with_ctr = get_option('with-ctr-drbg')
+if libdrgb_with_ctr
+    drbg_build_opts += [ '-DWITH_CTR_DRBG' ]
+
+    libdrbg_with_tdea = get_option('with-bc-tdea')
+    libdrbg_with_aes = get_option('with-bc-aes')
+    if libdrbg_with_tdea
+        drbg_build_opts += [ '-DWITH_BC_TDEA' ]
+        hash_build_opts += [ '-DWITH_BC_TDEA' ]
+    endif
+
+    if libdrbg_with_aes
+        drbg_build_opts += [ '-DWITH_BC_AES' ]
+    endif
+else
+    libdrbg_with_tdea = false
+    libdrbg_with_aes = false
+endif
+summary({'CTR DRBG': libdrgb_with_ctr,
+         'block cypher TDEA': libdrbg_with_tdea,
+         'block cypher AES': libdrbg_with_aes,},
+        section: 'libdrgb')
+
+libdrbg_small_footprint = get_option('small-footprint')
+if libdrbg_small_footprint
+    drbg_build_opts += [ '-DSMALL_MEMORY_FOOTPRINT' ]
+endif
+summary('small footprint', libdrbg_small_footprint, section: 'libdrgb')
+
+libdrbg_with_test_entropy_source = get_option('with_test_entropy_source')
+if libdrbg_with_test_entropy_source
+    drbg_build_opts += [ '-DWITH_TEST_ENTROPY_SOURCE' ]
+endif
+summary('test entropy source', libdrbg_with_test_entropy_source, section: 'libdrgb')
+
+libhash_strict_nist = get_option('strict-nist-hashes')
+if libhash_strict_nist
+    drbg_build_opts += [ '-DSTRICT_NIST_SP800_90A' ]
+    hash_build_opts += [ '-DWITH_HASH_CONF_OVERRIDE' ]
+    libhash_enabled_hashes = [
+        'sha1',
+        'sha224',
+        'sha256',
+        'sha384',
+        'sha512',
+        'sha512-224',
+        'sha512-256',
+    ]
+else
+    # XXX: remove CONF_OVERRIDE option and generate a config header instead
+    libhash_enabled_hashes = get_option('with-hashes')
+    if libhash_enabled_hashes.length() != 0
+        hash_build_opts += [ '-DWITH_HASH_CONF_OVERRIDE' ]
+    endif
+endif
+
+summary('strict NIST_SP800_90A', libhash_strict_nist, section: 'libhash')
+summary('hashes', libhash_enabled_hashes, section: 'libhash')
+
+foreach hash: libhash_enabled_hashes
+    hash_build_opts += '-DWITH_HASH_@0@'.format(hash.underscorify().to_upper())
+endforeach
+
+summary({'libdrbg built option': drbg_build_opts,
+         'libhash built option': hash_build_opts},
+         section: 'build options')
+
+# add_global_arguments([drbg_build_opts, hash_build_opts], language: 'c')
+
+drbg_sources = []
+
+subdir('libhash')
+
+if '-DWITH_BC_AES' in drbg_build_opts
+    subdir('aes')
+endif
+
+drbg_sources += files([
+    'ctr_drbg.c',
+    'drbg.c',
+    'entropy.c',
+    'hash_drbg.c',
+    'hmac_drbg.c',
+])
+
+drbg_lib = static_library(
+    meson.project_name(),
+    sources: drbg_sources,
+    c_args: drbg_build_opts,
+    dependencies: hash_dep
+)
+
+drbg_dep = declare_dependency(
+    link_with: drbg_lib,
+    compile_args: drbg_build_opts,
+    dependencies: hash_dep,
+)
+
+if get_option('with_test')
+    drbg_test = executable(
+        meson.project_name(),
+        sources: files('main.c',
+                       'drbg_tests/ctr_drbg_tests.c',
+                       'drbg_tests/hash_drbg_tests.c',
+                       'drbg_tests/hmac_drbg_tests.c',),
+        include_directories: 'drbg_tests',
+        dependencies: drbg_dep,
+    )
+    test('drbg_self_test', drbg_test)
+endif

--- a/meson.options
+++ b/meson.options
@@ -1,26 +1,30 @@
-option('with-hash-drbg', type: 'boolean', value: true)
-option('with-hmac-drbg', type: 'boolean', value: true)
-option('with-ctr-drbg', type: 'boolean', value: true)
-option('with-bc-tdea', type: 'boolean', value: true)
-option('with-bc-aes', type: 'boolean', value: true)
+option('with-hash-drbg', type: 'boolean', value: true, description: 'enables DRBG based on hash functions')
+option('with-hmac-drbg', type: 'boolean', value: true, description: 'enables DRBG based on HMA')
+option('with-ctr-drbg', type: 'boolean', value: true, description: 'enables DRBG based on block ciphers in counter mode')
+option('with-bc-tdea', type: 'boolean', value: true, description: 'enables TDEA as block cipher algorithm for CTR DRBG')
+option('with-bc-aes', type: 'boolean', value: true, description: 'enables AES as block cipher algorithm for CTR DRBG')
 
-option('small-footprint', type: 'boolean', value: false)
+option('small-footprint', type: 'boolean', value: false, description: 'use small footprint implementations ' +
+    'this mostly concerns AES where table based or compact SBOX variants are selected')
 
-option('strict-nist-hashes', type: 'boolean', value: true)
+option('strict-nist-hashes', type: 'boolean', value: true, description: 'enables NIST SP800 90A only hashes')
 
-option('with-hashes', type: 'array', choices: [
-    'bash224', 'bash256', 'bash384', 'bash512',
-    'belt',
-    'gostr34-11-94',
-    'md2', 'md4', 'md5',
-    'mdc2',
-    'ripemd160',
-    'sha0', 'sha1', 'sha2', 'sha3',
-    'sha3-224', 'sha3-256', 'sha3-384', 'sha3-512',
-    'sha224', 'sha256', 'sha384', 'sha512', 'sha512-224', 'sha512-256',
-    'shake256',
-    'sm3',
-    'streebog256', 'streebog512'])
+option('with-hashes', type: 'array',
+    choices: [
+        'bash224', 'bash256', 'bash384', 'bash512',
+        'belt',
+        'gostr34-11-94',
+        'md2', 'md4', 'md5',
+        'mdc2',
+        'ripemd160',
+        'sha0', 'sha1', 'sha2', 'sha3',
+        'sha3-224', 'sha3-256', 'sha3-384', 'sha3-512',
+        'sha224', 'sha256', 'sha384', 'sha512', 'sha512-224', 'sha512-256',
+        'shake256',
+        'sm3',
+        'streebog256', 'streebog512'],
+    deprecated: [ 'md2', 'md4', 'md5', 'mdc2', 'sha0', 'sha1', 'gostr34-11-94' ],
+    description: 'List of user defined hash algorithm')
 
-option('with_test_entropy_source', type: 'boolean', value: false)
-option('with_test', type: 'boolean', value: false)
+option('with_test_entropy_source', type: 'boolean', value: false, description: 'Use test Entropy source (Unix/Windows only)')
+option('with_test', type: 'boolean', value: false, description: 'Build self test binary')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,26 @@
+option('with-hash-drbg', type: 'boolean', value: true)
+option('with-hmac-drbg', type: 'boolean', value: true)
+option('with-ctr-drbg', type: 'boolean', value: true)
+option('with-bc-tdea', type: 'boolean', value: true)
+option('with-bc-aes', type: 'boolean', value: true)
+
+option('small-footprint', type: 'boolean', value: false)
+
+option('strict-nist-hashes', type: 'boolean', value: true)
+
+option('with-hashes', type: 'array', choices: [
+    'bash224', 'bash256', 'bash384', 'bash512',
+    'belt',
+    'gostr34-11-94',
+    'md2', 'md4', 'md5',
+    'mdc2',
+    'ripemd160',
+    'sha0', 'sha1', 'sha2', 'sha3',
+    'sha3-224', 'sha3-256', 'sha3-384', 'sha3-512',
+    'sha224', 'sha256', 'sha384', 'sha512', 'sha512-224', 'sha512-256',
+    'shake256',
+    'sm3',
+    'streebog256', 'streebog512'])
+
+option('with_test_entropy_source', type: 'boolean', value: false)
+option('with_test', type: 'boolean', value: false)


### PR DESCRIPTION
Meson buildsystem introduction.
Compare to the orig `makefile`, meson is building a static library for `libdrbg` and self test binary is built is `with_test` option is set to true (see `meson.options`).

One can build and run self test with th following:
```console
meson setup -Dstrict-nist-hashes=true -Dwith_test=true -Dwith_test_entropy_source=true build
meson compile -C build
meson test -C build
```

TODO:

- [x] options description
- [ ] src / include / test layout
- [ ] Add include directory in meson declared dependency (for libhash and libdrbg)
- [ ] generate configuration header (instead of `WITH_HASH_CONF_OVERRIDE` boilerplate)
- [ ] generate a `.pc` file ?

